### PR TITLE
Replacing Input alias with Output alias

### DIFF
--- a/community-members/Imperial College London/Scenario-Learning-Modules/DIY_Kits/Lab1_MonitorYourPlant/IoTCentral/Create_stream_analytics.md
+++ b/community-members/Imperial College London/Scenario-Learning-Modules/DIY_Kits/Lab1_MonitorYourPlant/IoTCentral/Create_stream_analytics.md
@@ -72,7 +72,7 @@ In the [previous step](Create_storage_account.md) you have created the storage a
 
 1. Complete the details as follows:
 
-    * Input alias: `data`.
+    * Output alias: `data`.
 
     * Click on `Select storage from your subscriptions`.
 


### PR DESCRIPTION
In the Output Job topology, We've to fill the `data` in the **Output alias** not in the Input alias as you can see below

![2021-08-14 (15)](https://user-images.githubusercontent.com/53372213/129445683-a85c1426-0554-4325-93b4-5eec12baeae1.png)
